### PR TITLE
Fix building.

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -6,3 +6,4 @@ public net.minecraft.world.level.block.DispenserBlock m_7216_(Lnet/minecraft/wor
 public-f net.minecraft.world.entity.animal.Chicken f_28233_ # FOOD_ITEMS
 public-f net.minecraft.world.entity.animal.Pig f_29458_ # FOOD_ITEMS
 public-f net.minecraft.world.entity.animal.Parrot f_29357_ # TAME_FOOD
+public net.minecraft.world.level.block.DropperBlock m_7216_(Lnet/minecraft/world/item/ItemStack;)Lnet/minecraft/core/dispenser/DispenseItemBehavior; # getDispenseMethod


### PR DESCRIPTION
I tried to build the 1.18.2 version of Farmers Delight and failed. 
After my check, there may be an AT that was missed.
I don't know why it happened, but it works.